### PR TITLE
improve menu coloring on mobile devices

### DIFF
--- a/style.css
+++ b/style.css
@@ -718,7 +718,7 @@ a:active {
 }
 
 .menu-1 ul ul li {
-	background-color: #182b5f;
+	background-color: #182b5f
 }
 
 .menu-1 li:hover,
@@ -753,6 +753,7 @@ a:active {
 	padding-left: 5px;
 	opacity: .75
 }
+
 .menu-1 li li.page_item_has_children > a:after,
 .menu-1 li li.menu-item-has-children > a:after {
 	content: '\25b6';
@@ -765,6 +766,18 @@ a:active {
 /* Small menu. */
 .menu-toggle {
 	display: none
+}
+
+.menu-toggle:hover,
+.menu-toggle.focus,
+.nav-menu a:hover,
+.nav-menu a.focus {
+	background-color: #182b5f
+}
+
+.menu-toggle,
+.nav-menu {
+	background-color: #253e80
 }
 
 /*--------------------------------------------------------------
@@ -989,7 +1002,6 @@ a:active {
 .comment-metadata a {
 	color: gray;
 	font-size: 14px;
-
 }
 
 .logged-in-as a {
@@ -1195,8 +1207,8 @@ object {
 		color: white;
 		margin: 0 auto;
 		width: 100%;
-    border: 0;
-    border-radius: 0;
+		border: 0;
+		border-radius: 0;
 	}
 
 	.toggled .menu-toggle {
@@ -1256,6 +1268,6 @@ object {
 	}
 
 	.menu-1 .nav-menu > li:first-child {
-	  margin-left: 0;
+		margin-left: 0;
 	}
 }


### PR DESCRIPTION
The current CSS file seems to be broken on mobile devices.
I tried to fix the issue with as little changes as possible. Given that I am a CSS newbie, you might want to review the changes carefully.

![before](https://user-images.githubusercontent.com/9089830/75119643-10c1d900-5685-11ea-886c-096f284d55c9.PNG)
![after](https://user-images.githubusercontent.com/9089830/75119645-128b9c80-5685-11ea-8d97-4c3dcc1d5b62.PNG)

Thanks for making and maintaining this theme!
